### PR TITLE
Fix misnamed parameter `do_lowercase` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ flaubert, log = XLMModel.from_pretrained(modelname, output_loading_info=True)
 print(log)
 
 # Load tokenizer
-flaubert_tokenizer = XLMTokenizer.from_pretrained(modelname, do_lower_case=False)
-
-# this line is important: by default, XLMTokenizer removes diacritics, even with do_lower_case=False flag
-flaubert_tokenizer.do_lowercase_and_remove_accent = False
+flaubert_tokenizer = XLMTokenizer.from_pretrained(modelname, do_lowercase_and_remove_accent=False)
 
 sentence="Le chat mange une pomme."
 sentence_lower = sentence.lower()


### PR DESCRIPTION
The reason why `do_lowercase_and_remove_accent` has to be set manually in the example is because the tokenizer initialization used `do_lowercase`, which does nothing (it does add a `do_lowercase` attribute to the tokenizer, which doe nothing with it since it doesn't know that it exists…).

Test it with

```python
import torch
from transformers import XLMTokenizer
modelname="xlm_bert_fra_base_lower" # Or absolute path to where you put the folder
flaubert_tokenizer = XLMTokenizer.from_pretrained(modelname, do_lowercase_and_remove_accent=False)
print(flaubert_tokenizer.do_lowercase_and_remove_accent)
```

which correctly prints `False`