### PR TITLE
Update pawsx_lr5e6_hf_base_cased.cfg

### DIFF
--- a/flue/examples/pawsx_lr5e6_hf_base_cased.cfg
+++ b/flue/examples/pawsx_lr5e6_hf_base_cased.cfg
@@ -10,7 +10,7 @@ epochs=30
 exp_name="pawsx_hf_"$model_fname
 exp_id="lr_"$lr
 
-data_dir=~/Data/FLUE/cls/processed/$cat
+data_dir=~/Data/FLUE/pawsx/processed
 model_name_or_path=~/pretrained_models/Flaubert/$model_fname
 output_dir=~/Experiments/FLUE/Flaubert/$exp_name/$exp_id
 


### PR DESCRIPTION
data_dir was referring to the text classification task folder.